### PR TITLE
added "everythingIsCollection" input option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Sets options globally for the Treeize instance.  This is an alias for `.options(
   input: {
     delimiter:          ':',    // delimiter between path segments, defaults to ':'
     detectCollections:  true,   // when true, plural path segments become collections
+    everythingIsCollection: false, //when true, every nested object is a collection (useful if you cannot guarantee that collections are in english plural form, e.g. when it's in a different language)
     uniformRows:        false,  // set to true if each row has identical signatures
   },
   output: {
@@ -173,6 +174,9 @@ This sets the delimiter to be used between path segments (e.g. the ":" in "child
 `input.detectCollections`<a name="optionsInputDetectCollections" />
 Enables/disables the default behavior of turning plural path segments (e.g. "subjects" vs. "subject") into collections instead of object paths.  **Note:** In order to properly merge multiple rows into the same collection item, the collection must have a base-level attribute(s) acting as a signature.
 [View test example (enabled)](https://github.com/kwhitley/treeize/blob/feature/multi-format/test/test.js#L79-86) | [or (disabled)](https://github.com/kwhitley/treeize/blob/feature/multi-format/test/test.js#L92-99)
+
+`input.everythingIsCollection`<a name="optionsInputEverythingIsCollection" />
+Default is false. When true, every nested object is a collection. That's useful if you cannot change the names of objects so you can not rely on the DetectCollections option.
 
 `input.uniformRows`<a name="optionsInputUniformRows" />
 By default row uniformity is disabled to allow the most flexible data merging.  This means each and every row of data that is processed (unless flat array-of-array data) will be analyzed and mapped individually into the final structure.  If your data rows have uniform attributes/columns, disable this for a performance increase.

--- a/lib/treeize.js
+++ b/lib/treeize.js
@@ -33,6 +33,7 @@ function Treeize(options) {
     input: {
       delimiter:          ':',
       detectCollections:  true,
+      everythingIsCollection: false,
       uniformRows:        false,
     },
     output: {
@@ -140,7 +141,7 @@ Treeize.prototype.signature = function(row, options, auto) {
       nodes.push(node)
     }
 
-    node.isCollection = !attr.node || (opt.input.detectCollections && inflection.pluralize(attr.node) === attr.node)
+    node.isCollection = !attr.node || (opt.input.detectCollections && inflection.pluralize(attr.node) === attr.node) || everythingIsCollection
 
     var collectionFlag = attr.node && attr.node.match(/^[\-\+]|[\-\+]$/g)
     if (collectionFlag) {

--- a/lib/treeize.js
+++ b/lib/treeize.js
@@ -141,7 +141,7 @@ Treeize.prototype.signature = function(row, options, auto) {
       nodes.push(node)
     }
 
-    node.isCollection = !attr.node || (opt.input.detectCollections && inflection.pluralize(attr.node) === attr.node) || everythingIsCollection
+    node.isCollection = !attr.node || (opt.input.detectCollections && inflection.pluralize(attr.node) === attr.node) || opt.input.everythingIsCollection
 
     var collectionFlag = attr.node && attr.node.match(/^[\-\+]|[\-\+]$/g)
     if (collectionFlag) {


### PR DESCRIPTION
For a current project I have to work on, all objects are in german language and I am not allowed to change the names. So I can not rely on the "detectCollections" input option.

I guess there might be other cases where one cannot rely on that, so I added the "everythingIsCollection" option. When true, every nested Object is a collection.