### PR TITLE
Proper null type checking

### DIFF
--- a/lib/treeize.js
+++ b/lib/treeize.js
@@ -2,12 +2,34 @@ var inflection  = require('inflection')
 var merge       = require('object-merge')
 var _           = require('lodash')
 
+/**
+ * Makes sure `null` values do not have their type evaluated
+ * as `object`
+ */
+function typeCheck (obj) {
+  let type;
+
+  if (obj === undefined) {
+    type = 'undefined';
+  } else if (obj === null) {
+    type = 'null';
+  } else if (_.isObject(obj)) {
+    type = 'object';
+  } else if (_.isArray(obj)) {
+    type = 'array';
+  } else {
+    type = typeof obj;
+  }
+
+  return type;
+}
+
 var isArray = function(item) {
   return _.isArray(item)
 }
 
 var isEmpty = function(item) {
-  return !item || (typeof item === 'object' && !Object.keys(item).length)
+  return !item || (typeCheck(item) === 'object' && !Object.keys(item).length)
 }
 
 var where = function(collection, props) {
@@ -116,7 +138,7 @@ Treeize.prototype.signature = function(row, options, auto) {
     let value = row[key]
     var attr        = {}
 
-    attr.key        = typeof key === 'number' ? key : key//.replace(/^[\*\-\+]|[\*\-\+]$/g,'')
+    attr.key        = typeCheck(key) === 'number' ? key : key//.replace(/^[\*\-\+]|[\*\-\+]$/g,'')
     attr.fullPath   = isRowAnArray ? value : key
     attr.split      = attr.fullPath.split(opt.input.delimiter)
     attr.path       = attr.split.slice(0,attr.split.length-1).join(opt.input.delimiter)
@@ -201,7 +223,7 @@ Treeize.prototype.clearSignature = function() {
 Treeize.prototype.grow = function(data, options) {
   var opt = merge(this._options, options || {})
   // chain past if no data to grow
-  if (typeof data !== 'object' || !data.length) {
+  if (typeCheck(data) !== 'object' || !data.length) {
     return this
   }
 
@@ -269,7 +291,7 @@ Treeize.prototype.grow = function(data, options) {
       for (var key in row) {
         let value = row[key]
 
-        if (typeof key === 'string') {
+        if (typeCheck(key) === 'string') {
           var clean = key.replace(/^[\*\-\+]|[\*\-\+]$/g,'')
           if (clean !== key) {
             //this.log('cleaning key "' + key + '" and embedding as "' + clean + '"')
@@ -392,7 +414,7 @@ Treeize.prototype.grow = function(data, options) {
 
             //this.log('inserting into non-collection node')
             //if (!trail[node.name]) { // TODO: CONSIDER: add typeof check to this for possible overwriting
-            if (!trail[node.name] || (opt.output.objectOverwrite && (typeof trail[node.name] !== typeof blueprintExtended))) {
+            if (!trail[node.name] || (opt.output.objectOverwrite && (typeCheck(trail[node.name]) !== typeCheck(blueprintExtended)))) {
               // node attribute doesnt exist, create object
               //this.log('create object')
               trail[node.name] = blueprintExtended
@@ -401,7 +423,7 @@ Treeize.prototype.grow = function(data, options) {
               // node attribute exists, set path for next pass
               // TODO: extend trail??
               //this.log('object at node "' + node.name + '" exists as "' + trail[node.name] + '", skipping insertion and adding trail')
-              if (typeof trail[node.name] === 'object') {
+              if (typeCheck(trail[node.name]) === 'object') {
                 trail[node.name] = merge(trail[node.name], blueprintExtended)
               }
               //this.log('trail[node.name] updated to "' + trail[node.name])


### PR DESCRIPTION
Fixes https://github.com/kwhitley/treeize/issues/35.  
The old behavior remains if `output: {prune: true}` (the default prune value) thus, set the prune option to false in order to support null values `output: {prune: false}`.
